### PR TITLE
feat: 발송 옵션 조회 기능 일부 수정 & 옵션 선택에 따른 질문 조회 기능

### DIFF
--- a/src/main/java/com/nexters/covid/letter/api/LetterController.java
+++ b/src/main/java/com/nexters/covid/letter/api/LetterController.java
@@ -30,7 +30,7 @@ public class LetterController {
     return new BaseResponse<>(200, 0, "", options);
   }
 
-  @GetMapping("/letters/options/{optionId}")
+  @GetMapping("/letters/options/{optionId}/questions")
   public BaseResponse<List<QuestionResponse>> findQuestionsByOptionId(@PathVariable("optionId") Long optionId) {
     List<QuestionResponse> questions = letterService.findQuestionsByOptionId(optionId);
     return new BaseResponse<>(200, 0, "", questions);

--- a/src/main/java/com/nexters/covid/letter/api/LetterController.java
+++ b/src/main/java/com/nexters/covid/letter/api/LetterController.java
@@ -31,8 +31,8 @@ public class LetterController {
   }
 
   @GetMapping("/letters/options/{optionId}")
-  public BaseResponse<List<QuestionResponse>> questions(@PathVariable("optionId") Long optionId) {
-    List<QuestionResponse> questions = letterService.findQuestions(optionId);
+  public BaseResponse<List<QuestionResponse>> findQuestionsByOptionId(@PathVariable("optionId") Long optionId) {
+    List<QuestionResponse> questions = letterService.findQuestionsByOptionId(optionId);
     return new BaseResponse<>(200, 0, "", questions);
   }
 }

--- a/src/main/java/com/nexters/covid/letter/api/LetterController.java
+++ b/src/main/java/com/nexters/covid/letter/api/LetterController.java
@@ -1,10 +1,12 @@
 package com.nexters.covid.letter.api;
 
 import com.nexters.covid.base.BaseResponse;
+import com.nexters.covid.letter.api.dto.LetterResponse;
 import com.nexters.covid.letter.api.dto.OptionResponse;
 import com.nexters.covid.letter.service.LetterService;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -14,9 +16,15 @@ public class LetterController {
 
   private final LetterService letterService;
 
-  @GetMapping("/letter/option")
+  @GetMapping("/letters/options")
   public BaseResponse<List<OptionResponse>> options() {
     List<OptionResponse> options = letterService.options();
     return new BaseResponse<>(200, 0, "", options);
+  }
+
+  @GetMapping("/letters")
+  public BaseResponse<List<LetterResponse>> letters(Authentication authentication) {
+    List<LetterResponse> letters = letterService.letters(authentication.getName());;
+    return new BaseResponse<>(200, 0, "", letters);
   }
 }

--- a/src/main/java/com/nexters/covid/letter/api/LetterController.java
+++ b/src/main/java/com/nexters/covid/letter/api/LetterController.java
@@ -3,11 +3,13 @@ package com.nexters.covid.letter.api;
 import com.nexters.covid.base.BaseResponse;
 import com.nexters.covid.letter.api.dto.LetterResponse;
 import com.nexters.covid.letter.api.dto.OptionResponse;
+import com.nexters.covid.letter.api.dto.QuestionResponse;
 import com.nexters.covid.letter.service.LetterService;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RestController;
 
 @RequiredArgsConstructor
@@ -16,15 +18,21 @@ public class LetterController {
 
   private final LetterService letterService;
 
+  @GetMapping("/letters")
+  public BaseResponse<List<LetterResponse>> findLettersByEmail(Authentication authentication) {
+    List<LetterResponse> letters = letterService.findLettersByEmail(authentication.getName());
+    return new BaseResponse<>(200, 0, "", letters);
+  }
+
   @GetMapping("/letters/options")
-  public BaseResponse<List<OptionResponse>> options() {
-    List<OptionResponse> options = letterService.options();
+  public BaseResponse<List<OptionResponse>> findAllOptions() {
+    List<OptionResponse> options = letterService.findAllOptions();
     return new BaseResponse<>(200, 0, "", options);
   }
 
-  @GetMapping("/letters")
-  public BaseResponse<List<LetterResponse>> letters(Authentication authentication) {
-    List<LetterResponse> letters = letterService.letters(authentication.getName());;
-    return new BaseResponse<>(200, 0, "", letters);
+  @GetMapping("/letters/options/{optionId}")
+  public BaseResponse<List<QuestionResponse>> questions(@PathVariable("optionId") Long optionId) {
+    List<QuestionResponse> questions = letterService.findQuestions(optionId);
+    return new BaseResponse<>(200, 0, "", questions);
   }
 }

--- a/src/main/java/com/nexters/covid/letter/api/dto/LetterResponse.java
+++ b/src/main/java/com/nexters/covid/letter/api/dto/LetterResponse.java
@@ -3,8 +3,8 @@ package com.nexters.covid.letter.api.dto;
 import static org.springframework.beans.BeanUtils.copyProperties;
 
 import com.nexters.covid.letter.domain.Letter;
-import com.nexters.covid.user.domain.User;
-import java.util.List;
+import com.nexters.covid.letter.domain.State;
+import com.nexters.covid.letter.domain.Sticker;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -12,12 +12,21 @@ import lombok.Setter;
 @Setter
 public class LetterResponse {
 
-  private String name;
-  private String email;
-  private List<Letter> letters;
+  private String title;
 
-  public LetterResponse(User source) {
+  private String contents;
+
+  private String email;
+
+  private State state;
+
+  private Sticker sticker;
+
+  private Long questionId;
+
+  private String encryptedId;
+
+  public LetterResponse(Letter source) {
     copyProperties(source, this);
-    this.letters = source.letters();
   }
 }

--- a/src/main/java/com/nexters/covid/letter/api/dto/LetterResponse.java
+++ b/src/main/java/com/nexters/covid/letter/api/dto/LetterResponse.java
@@ -5,6 +5,7 @@ import static org.springframework.beans.BeanUtils.copyProperties;
 import com.nexters.covid.letter.domain.Letter;
 import com.nexters.covid.letter.domain.State;
 import com.nexters.covid.letter.domain.Sticker;
+import java.time.LocalDateTime;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -25,6 +26,8 @@ public class LetterResponse {
   private Long questionId;
 
   private String encryptedId;
+
+  private LocalDateTime createdDate;
 
   public LetterResponse(Letter source) {
     copyProperties(source, this);

--- a/src/main/java/com/nexters/covid/letter/api/dto/OptionResponse.java
+++ b/src/main/java/com/nexters/covid/letter/api/dto/OptionResponse.java
@@ -2,9 +2,7 @@ package com.nexters.covid.letter.api.dto;
 
 import static org.springframework.beans.BeanUtils.copyProperties;
 
-import com.nexters.covid.letter.domain.Question;
 import com.nexters.covid.letter.domain.SendOption;
-import java.util.List;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -14,10 +12,8 @@ public class OptionResponse {
 
   private String text;
   private Long covidStat;
-  private List<Question> questions;
 
   public OptionResponse(SendOption source) {
     copyProperties(source, this);
-    this.questions = source.questions();
   }
 }

--- a/src/main/java/com/nexters/covid/letter/api/dto/QuestionResponse.java
+++ b/src/main/java/com/nexters/covid/letter/api/dto/QuestionResponse.java
@@ -2,19 +2,17 @@ package com.nexters.covid.letter.api.dto;
 
 import static org.springframework.beans.BeanUtils.copyProperties;
 
-import com.nexters.covid.letter.domain.SendOption;
+import com.nexters.covid.letter.domain.Question;
 import lombok.Getter;
 import lombok.Setter;
 
 @Getter
 @Setter
-public class OptionResponse {
+public class QuestionResponse {
 
-  private Long id;
   private String text;
-  private Long covidStat;
 
-  public OptionResponse(SendOption source) {
+  public QuestionResponse(Question source) {
     copyProperties(source, this);
   }
 }

--- a/src/main/java/com/nexters/covid/letter/domain/Letter.java
+++ b/src/main/java/com/nexters/covid/letter/domain/Letter.java
@@ -3,7 +3,6 @@ package com.nexters.covid.letter.domain;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.nexters.covid.base.BaseEntity;
 import com.nexters.covid.user.domain.User;
-import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
@@ -45,7 +44,7 @@ public class Letter extends BaseEntity {
 
   private String answer;
 
-  private String questionId;
+  private Long questionId;
 
   private String encryptedId;
 }

--- a/src/main/java/com/nexters/covid/letter/domain/LetterRepository.java
+++ b/src/main/java/com/nexters/covid/letter/domain/LetterRepository.java
@@ -1,6 +1,9 @@
 package com.nexters.covid.letter.domain;
 
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface LetterRepository extends JpaRepository<Letter, Long> {
+
+  List<Letter> findLettersByEmail(String email);
 }

--- a/src/main/java/com/nexters/covid/letter/domain/QuestionRepository.java
+++ b/src/main/java/com/nexters/covid/letter/domain/QuestionRepository.java
@@ -1,0 +1,9 @@
+package com.nexters.covid.letter.domain;
+
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface QuestionRepository extends JpaRepository<Question, Long> {
+
+  List<Question> findQuestionsBySendOptionIdEqualsOrSendOptionIdEquals(Long id, Long ge);
+}

--- a/src/main/java/com/nexters/covid/letter/domain/QuestionRepository.java
+++ b/src/main/java/com/nexters/covid/letter/domain/QuestionRepository.java
@@ -5,5 +5,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface QuestionRepository extends JpaRepository<Question, Long> {
 
-  List<Question> findQuestionsBySendOptionIdEqualsOrSendOptionIdEquals(Long id, Long ge);
+  List<Question> findQuestionsBySendOptionIdEqualsOrSendOptionIdEquals(Long optionId, Long commonOptionId);
 }

--- a/src/main/java/com/nexters/covid/letter/service/LetterService.java
+++ b/src/main/java/com/nexters/covid/letter/service/LetterService.java
@@ -17,6 +17,7 @@ public class LetterService {
   private final LetterRepository letterRepository;
   private final SendOptionRepository sendOptionRepository;
 
+  @Transactional(readOnly = true)
   public List<OptionResponse> options() {
     return sendOptionRepository.findAll()
         .stream()

--- a/src/main/java/com/nexters/covid/letter/service/LetterService.java
+++ b/src/main/java/com/nexters/covid/letter/service/LetterService.java
@@ -1,22 +1,35 @@
 package com.nexters.covid.letter.service;
 
+import com.nexters.covid.letter.api.dto.LetterResponse;
 import com.nexters.covid.letter.api.dto.OptionResponse;
+import com.nexters.covid.letter.domain.LetterRepository;
 import com.nexters.covid.letter.domain.SendOptionRepository;
+import com.nexters.covid.user.domain.UserRepository;
 import java.util.List;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @RequiredArgsConstructor
 @Service
 public class LetterService {
 
+  private final LetterRepository letterRepository;
   private final SendOptionRepository sendOptionRepository;
 
   public List<OptionResponse> options() {
     return sendOptionRepository.findAllJoinFetch()
         .stream()
         .map(OptionResponse::new)
+        .collect(Collectors.toList());
+  }
+
+  @Transactional(readOnly = true)
+  public List<LetterResponse> letters(String email) {
+    return letterRepository.findLettersByEmail(email)
+        .stream()
+        .map(LetterResponse::new)
         .collect(Collectors.toList());
   }
 }

--- a/src/main/java/com/nexters/covid/letter/service/LetterService.java
+++ b/src/main/java/com/nexters/covid/letter/service/LetterService.java
@@ -2,7 +2,9 @@ package com.nexters.covid.letter.service;
 
 import com.nexters.covid.letter.api.dto.LetterResponse;
 import com.nexters.covid.letter.api.dto.OptionResponse;
+import com.nexters.covid.letter.api.dto.QuestionResponse;
 import com.nexters.covid.letter.domain.LetterRepository;
+import com.nexters.covid.letter.domain.QuestionRepository;
 import com.nexters.covid.letter.domain.SendOptionRepository;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -16,9 +18,18 @@ public class LetterService {
 
   private final LetterRepository letterRepository;
   private final SendOptionRepository sendOptionRepository;
+  private final QuestionRepository questionRepository;
 
   @Transactional(readOnly = true)
-  public List<OptionResponse> options() {
+  public List<LetterResponse> findLettersByEmail(String email) {
+    return letterRepository.findLettersByEmail(email)
+        .stream()
+        .map(LetterResponse::new)
+        .collect(Collectors.toList());
+  }
+
+  @Transactional(readOnly = true)
+  public List<OptionResponse> findAllOptions() {
     return sendOptionRepository.findAll()
         .stream()
         .map(OptionResponse::new)
@@ -26,10 +37,10 @@ public class LetterService {
   }
 
   @Transactional(readOnly = true)
-  public List<LetterResponse> letters(String email) {
-    return letterRepository.findLettersByEmail(email)
+  public List<QuestionResponse> findQuestions(Long questionId) {
+    return questionRepository.findQuestionsBySendOptionIdEqualsOrSendOptionIdEquals(questionId, 3L)
         .stream()
-        .map(LetterResponse::new)
+        .map(QuestionResponse::new)
         .collect(Collectors.toList());
   }
 }

--- a/src/main/java/com/nexters/covid/letter/service/LetterService.java
+++ b/src/main/java/com/nexters/covid/letter/service/LetterService.java
@@ -4,7 +4,6 @@ import com.nexters.covid.letter.api.dto.LetterResponse;
 import com.nexters.covid.letter.api.dto.OptionResponse;
 import com.nexters.covid.letter.domain.LetterRepository;
 import com.nexters.covid.letter.domain.SendOptionRepository;
-import com.nexters.covid.user.domain.UserRepository;
 import java.util.List;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/nexters/covid/letter/service/LetterService.java
+++ b/src/main/java/com/nexters/covid/letter/service/LetterService.java
@@ -18,7 +18,7 @@ public class LetterService {
   private final SendOptionRepository sendOptionRepository;
 
   public List<OptionResponse> options() {
-    return sendOptionRepository.findAllJoinFetch()
+    return sendOptionRepository.findAll()
         .stream()
         .map(OptionResponse::new)
         .collect(Collectors.toList());

--- a/src/main/java/com/nexters/covid/letter/service/LetterService.java
+++ b/src/main/java/com/nexters/covid/letter/service/LetterService.java
@@ -37,7 +37,7 @@ public class LetterService {
   }
 
   @Transactional(readOnly = true)
-  public List<QuestionResponse> findQuestions(Long questionId) {
+  public List<QuestionResponse> findQuestionsByOptionId(Long questionId) {
     return questionRepository.findQuestionsBySendOptionIdEqualsOrSendOptionIdEquals(questionId, 3L)
         .stream()
         .map(QuestionResponse::new)

--- a/src/main/java/com/nexters/covid/user/api/UserController.java
+++ b/src/main/java/com/nexters/covid/user/api/UserController.java
@@ -1,7 +1,6 @@
 package com.nexters.covid.user.api;
 
 import com.nexters.covid.base.BaseResponse;
-import com.nexters.covid.letter.api.dto.LetterResponse;
 import com.nexters.covid.user.api.dto.LoginRequest;
 import com.nexters.covid.user.api.dto.LoginResponse;
 import com.nexters.covid.user.api.dto.UserResponse;
@@ -28,11 +27,5 @@ public class UserController {
   public BaseResponse<UserResponse> findUser(Authentication authentication) {
     UserResponse user = userService.findUserEmail(authentication.getName());
     return new BaseResponse<>(200, 0, "", user);
-  }
-
-  @GetMapping("/user/letter")
-  public BaseResponse<LetterResponse> letters(Authentication authentication) {
-    LetterResponse letters = userService.letters(authentication.getName());;
-    return new BaseResponse<>(200, 0, "", letters);
   }
 }

--- a/src/main/java/com/nexters/covid/user/service/UserService.java
+++ b/src/main/java/com/nexters/covid/user/service/UserService.java
@@ -1,6 +1,5 @@
 package com.nexters.covid.user.service;
 
-import com.nexters.covid.letter.api.dto.LetterResponse;
 import com.nexters.covid.user.api.dto.LoginRequest;
 import com.nexters.covid.user.api.dto.LoginResponse;
 import com.nexters.covid.user.api.dto.UserResponse;
@@ -44,11 +43,5 @@ public class UserService {
     User user = userRepository.findUserByEmail(email)
         .orElseThrow(() -> new RuntimeException("사용자가 없습니다."));
     return new UserResponse(user);
-  }
-
-  @Transactional(readOnly = true)
-  public LetterResponse letters(String email) {
-    User user = userRepository.findUserAndLettersByEmail(email);
-    return new LetterResponse(user);
   }
 }

--- a/src/main/resources/data-h2.sql
+++ b/src/main/resources/data-h2.sql
@@ -7,6 +7,7 @@ values ('ANSWER1', 'CONTENTS1', 'ENCRYPTED1', 'LETTER_TO1', 'email', 'BLUE', 2, 
 
 insert into send_option (text, covid_stat) values ('테스트', 1000);
 insert into send_option (text, covid_stat) values ('테스트2', 2000);
+insert into send_option (text, covid_stat) values ('기본질문', 0);
 
 insert into question (text, send_option_id) values ('테스트1에 1', 1);
 insert into question (text, send_option_id) values ('테스트1에 2', 1);
@@ -14,3 +15,7 @@ insert into question (text, send_option_id) values ('테스트1에 3', 1);
 
 insert into question (text, send_option_id) values ('테스트2에 1', 2);
 insert into question (text, send_option_id) values ('테스트2에 2', 2);
+
+insert into question (text, send_option_id) values ('기본 질문1', 3);
+insert into question (text, send_option_id) values ('기본 질문2', 3);
+insert into question (text, send_option_id) values ('기본 질문3', 3);

--- a/src/main/resources/data-h2.sql
+++ b/src/main/resources/data-h2.sql
@@ -1,9 +1,9 @@
 insert into user (email, identifier, name) values ('email', 'identifier', 'name');
 
 insert into letter (answer, contents, encrypted_id, letter_to, email, sticker, question_id, state, title, user_id)
-values ('ANSWER', 'CONTENTS', 'ENCRYPTED', 'LETTER_TO', 'email', 'A', 'HAPPY', 'PENDING', 'TITLE', 1);
+values ('ANSWER', 'CONTENTS', 'ENCRYPTED', 'LETTER_TO', 'email', 'HAPPY', 1 , 'PENDING', 'TITLE', 1);
 insert into letter (answer, contents, encrypted_id, letter_to, email, sticker, question_id, state, title, user_id)
-values ('ANSWER1', 'CONTENTS1', 'ENCRYPTED1', 'LETTER_TO1', 'email', 'A', 'BLUE', 'PENDING', 'TITLE1', 1);
+values ('ANSWER1', 'CONTENTS1', 'ENCRYPTED1', 'LETTER_TO1', 'email', 'BLUE', 2, 'PENDING', 'TITLE1', 1);
 
 insert into send_option (text, covid_stat) values ('테스트', 1000);
 insert into send_option (text, covid_stat) values ('테스트2', 2000);

--- a/src/test/java/com/nexters/covid/letter/domain/QuestionRepositoryTest.java
+++ b/src/test/java/com/nexters/covid/letter/domain/QuestionRepositoryTest.java
@@ -18,7 +18,9 @@ public class QuestionRepositoryTest {
   @Test
   @DisplayName("[QuestionRepository] 선택한 옵션에 따른 질문과 공통 질문 조회 테스트")
   void findQuestionByOptionTest() {
-    List<Question> questions = questionRepository.findQuestionsBySendOptionIdEqualsOrSendOptionIdEquals(1L, 3L);
+    long normalSendOptionId = 1L;
+    long commonSendOptionId = 3L;
+    List<Question> questions = questionRepository.findQuestionsBySendOptionIdEqualsOrSendOptionIdEquals(normalSendOptionId, commonSendOptionId);
 
     List<Long> sendOptionIds = questions.stream()
         .map(q -> q.getSendOption().getId())

--- a/src/test/java/com/nexters/covid/letter/domain/QuestionRepositoryTest.java
+++ b/src/test/java/com/nexters/covid/letter/domain/QuestionRepositoryTest.java
@@ -1,0 +1,30 @@
+package com.nexters.covid.letter.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+@DataJpaTest
+public class QuestionRepositoryTest {
+
+  @Autowired
+  QuestionRepository questionRepository;
+
+  @Test
+  @DisplayName("[QuestionRepository] 선택한 옵션에 따른 질문과 공통 질문 조회 테스트")
+  void findQuestionByOptionTest() {
+    List<Question> questions = questionRepository.findQuestionsBySendOptionIdEqualsOrSendOptionIdEquals(1L, 3L);
+
+    List<Long> sendOptionIds = questions.stream()
+        .map(q -> q.getSendOption().getId())
+        .collect(Collectors.toList());
+
+    assertThat(sendOptionIds.contains(1L)).isTrue();
+    assertThat(sendOptionIds.contains(3L)).isTrue();
+  }
+}

--- a/src/test/java/com/nexters/covid/letter/domain/SendOptionRepositoryTest.java
+++ b/src/test/java/com/nexters/covid/letter/domain/SendOptionRepositoryTest.java
@@ -15,7 +15,7 @@ public class SendOptionRepositoryTest {
   SendOptionRepository sendOptionRepository;
 
   @Test
-  @DisplayName("[SendOption] join fetch 테스트")
+  @DisplayName("[SendOptionRepository] join fetch 테스트")
   void fetchJoinTest() {
     List<SendOption> options = sendOptionRepository.findAllJoinFetch();
 

--- a/src/test/java/com/nexters/covid/letter/domain/SendOptionRepositoryTest.java
+++ b/src/test/java/com/nexters/covid/letter/domain/SendOptionRepositoryTest.java
@@ -3,6 +3,7 @@ package com.nexters.covid.letter.domain;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.List;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
@@ -14,6 +15,7 @@ public class SendOptionRepositoryTest {
   SendOptionRepository sendOptionRepository;
 
   @Test
+  @DisplayName("[SendOption] join fetch 테스트")
   void fetchJoinTest() {
     List<SendOption> options = sendOptionRepository.findAllJoinFetch();
 

--- a/src/test/java/resources/data-h2.sql
+++ b/src/test/java/resources/data-h2.sql
@@ -7,6 +7,7 @@ values ('ANSWER1', 'CONTENTS1', 'ENCRYPTED1', 'LETTER_TO1', 'email', 'A', 'BLUE'
 
 insert into send_option (text, covid_stat) values ('테스트', 1000);
 insert into send_option (text, covid_stat) values ('테스트2', 2000);
+insert into send_option (text, covid_stat) values ('기본질문', 0);
 
 insert into question (text, send_option_id) values ('테스트1에 1', 1);
 insert into question (text, send_option_id) values ('테스트1에 2', 1);
@@ -14,3 +15,7 @@ insert into question (text, send_option_id) values ('테스트1에 3', 1);
 
 insert into question (text, send_option_id) values ('테스트2에 1', 2);
 insert into question (text, send_option_id) values ('테스트2에 2', 2);
+
+insert into question (text, send_option_id) values ('기본 질문1', 3);
+insert into question (text, send_option_id) values ('기본 질문2', 3);
+insert into question (text, send_option_id) values ('기본 질문3', 3);


### PR DESCRIPTION
#### 편지 API 개발 Nexters/covid-letter-server#3

- 발송 옵션 조회 기능 메소드명 수정
- 편지 목록 조회시, 사용자 정보 같이 받아오지 않도록 수정
- EndPoint 변경
- 옵션 선택에 따른 질문 조회 기능 추가