### PR TITLE
fix: 편지 조회 및 부치지 못한 편지에 대한 처리

### DIFF
--- a/src/main/java/com/nexters/covid/letter/api/LetterController.java
+++ b/src/main/java/com/nexters/covid/letter/api/LetterController.java
@@ -54,9 +54,15 @@ public class LetterController {
     return new BaseResponse<>(200, 0, "", letter);
   }
 
-  @PutMapping("/letters/{encryptedId}")
+  @PutMapping("/letters/{encryptedId}/state")
   public BaseResponse<LetterResponse> updateLetterState(@PathVariable("encryptedId") String encryptedId) {
     LetterResponse letter = letterService.updateLetterState(encryptedId);
+    return new BaseResponse<>(200, 0, "", letter);
+  }
+
+  @PutMapping("/letters/{encryptedId}")
+  public BaseResponse<LetterResponse> updateLetter(@PathVariable("encryptedId") String encryptedId, @RequestBody LetterRequest letterRequest) {
+    LetterResponse letter = letterService.updateLetter(encryptedId, letterRequest);
     return new BaseResponse<>(200, 0, "", letter);
   }
 }

--- a/src/main/java/com/nexters/covid/letter/api/LetterController.java
+++ b/src/main/java/com/nexters/covid/letter/api/LetterController.java
@@ -44,8 +44,8 @@ public class LetterController {
   }
 
   @PostMapping("/letters")
-  public BaseResponse<LetterResponse> saveLetter(@RequestBody LetterRequest letterRequest) {
-    LetterResponse letter = letterService.saveLetter(letterRequest);
+  public BaseResponse<LetterResponse> saveLetter(@RequestBody LetterRequest letterRequest, Authentication authentication) {
+    LetterResponse letter = letterService.saveLetter(letterRequest, authentication.getName());
     return new BaseResponse<>(200, 0, "", letter);
   }
 

--- a/src/main/java/com/nexters/covid/letter/api/LetterController.java
+++ b/src/main/java/com/nexters/covid/letter/api/LetterController.java
@@ -14,6 +14,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RequiredArgsConstructor
@@ -23,8 +24,9 @@ public class LetterController {
   private final LetterService letterService;
 
   @GetMapping("/letters")
-  public BaseResponse<List<LetterResponse>> findLettersByEmail(Authentication authentication) {
-    List<LetterResponse> letters = letterService.findLettersByEmail(authentication.getName());
+  public BaseResponse<List<LetterResponse>> findLettersByEmail(Authentication authentication,
+      @RequestParam("unposted") boolean unposted) {
+    List<LetterResponse> letters = letterService.findLettersByEmail(authentication.getName(), unposted);
     return new BaseResponse<>(200, 0, "", letters);
   }
 
@@ -55,13 +57,15 @@ public class LetterController {
   }
 
   @PutMapping("/letters/{encryptedId}/state")
-  public BaseResponse<LetterResponse> updateLetterState(@PathVariable("encryptedId") String encryptedId) {
+  public BaseResponse<LetterResponse> updateLetterState(
+      @PathVariable("encryptedId") String encryptedId) {
     LetterResponse letter = letterService.updateLetterState(encryptedId);
     return new BaseResponse<>(200, 0, "", letter);
   }
 
   @PutMapping("/letters/{encryptedId}")
-  public BaseResponse<LetterResponse> updateLetter(@PathVariable("encryptedId") String encryptedId, @RequestBody LetterRequest letterRequest) {
+  public BaseResponse<LetterResponse> updateLetter(@PathVariable("encryptedId") String encryptedId,
+      @RequestBody LetterRequest letterRequest) {
     LetterResponse letter = letterService.updateLetter(encryptedId, letterRequest);
     return new BaseResponse<>(200, 0, "", letter);
   }

--- a/src/main/java/com/nexters/covid/letter/api/dto/LetterRequest.java
+++ b/src/main/java/com/nexters/covid/letter/api/dto/LetterRequest.java
@@ -19,4 +19,11 @@ public class LetterRequest {
   private Long questionId;
 
   private Long sendOptionId;
+
+  public Long markLetterSendOptionId() {
+    if (sendOptionId == null) {
+      return 7L;
+    }
+    return sendOptionId;
+  }
 }

--- a/src/main/java/com/nexters/covid/letter/api/dto/LetterRequest.java
+++ b/src/main/java/com/nexters/covid/letter/api/dto/LetterRequest.java
@@ -12,7 +12,7 @@ public class LetterRequest {
 
   private String contents;
 
-  private String email;
+//  private String letterTo;
 
   private Sticker sticker;
 

--- a/src/main/java/com/nexters/covid/letter/api/dto/LetterResponse.java
+++ b/src/main/java/com/nexters/covid/letter/api/dto/LetterResponse.java
@@ -22,6 +22,8 @@ public class LetterResponse {
 
   private String email;
 
+  private String name;
+
   private State state;
 
   private Sticker sticker;
@@ -45,6 +47,7 @@ public class LetterResponse {
   public LetterResponse(Letter source, Question question) {
     this(source);
     this.questionText = question.getText();
+    this.name = source.getUser().getName();
   }
 
   private String decodeContents(String contents) {

--- a/src/main/java/com/nexters/covid/letter/api/dto/LetterResponse.java
+++ b/src/main/java/com/nexters/covid/letter/api/dto/LetterResponse.java
@@ -39,11 +39,7 @@ public class LetterResponse {
   public LetterResponse(Letter source) {
     copyProperties(source, this);
     this.contents = decodeContents(source.getContents());
-  }
-
-  public LetterResponse(Letter source, SendOption option) {
-    this(source);
-    this.sendOptionText = option.getText();
+    this.sendOptionText = source.getSendOption().getText();
   }
 
   public LetterResponse(Letter source, Question question) {

--- a/src/main/java/com/nexters/covid/letter/domain/Letter.java
+++ b/src/main/java/com/nexters/covid/letter/domain/Letter.java
@@ -6,16 +6,19 @@ import static org.apache.commons.codec.binary.Base64.encodeBase64String;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.nexters.covid.base.BaseEntity;
 import com.nexters.covid.letter.api.dto.LetterRequest;
+import com.nexters.covid.letter.domain.sendoption.SendOption;
 import com.nexters.covid.user.domain.User;
 import java.util.UUID;
 import javax.persistence.Entity;
 import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
+import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
+import javax.persistence.OneToOne;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -49,11 +52,13 @@ public class Letter extends BaseEntity {
 
   private Long questionId;
 
-  private Long sendOptionId;
+  @OneToOne(fetch = FetchType.EAGER)
+  @JoinColumn(name = "send_option_id")
+  private SendOption sendOption;
 
   private String encryptedId;
 
-  public Letter(LetterRequest request, User user) {
+  public Letter(LetterRequest request, User user, SendOption sendOption) {
     this.user = user;
     this.letterTo = request.getEmail();
     this.title = request.getTitle();
@@ -62,7 +67,7 @@ public class Letter extends BaseEntity {
     this.state = State.PENDING;
     this.sticker = request.getSticker();
     this.questionId = request.getQuestionId();
-    this.sendOptionId = markLetterSendOptionId(request.getSendOptionId());
+    this.sendOption = sendOption;
     this.encryptedId = generateEncryptedId();
   }
 
@@ -84,17 +89,11 @@ public class Letter extends BaseEntity {
     return new String(decodeBase64(this.contents));
   }
 
-  public Long markLetterSendOptionId(Long sendOptionId) {
-    if (sendOptionId == null) {
-      return 7L;
-    }
-    return sendOptionId;
+  public void updateLetterSendOption(SendOption sendOption) {
+    this.sendOption = sendOption;
   }
 
-  public void updateLetterSendOption(Long sendOptionId) {
-    if (this.sendOptionId != 7) {
-      throw new RuntimeException("발송 옵션이 이미 설정되어 있습니다.");
-    }
-    this.sendOptionId = sendOptionId;
+  public boolean unpostedSendOption() {
+    return sendOption.isUnpostedLetter();
   }
 }

--- a/src/main/java/com/nexters/covid/letter/domain/Letter.java
+++ b/src/main/java/com/nexters/covid/letter/domain/Letter.java
@@ -90,4 +90,11 @@ public class Letter extends BaseEntity {
     }
     return sendOptionId;
   }
+
+  public void updateLetterSendOption(Long sendOptionId) {
+    if (this.sendOptionId != 7) {
+      throw new RuntimeException("발송 옵션이 이미 설정되어 있습니다.");
+    }
+    this.sendOptionId = sendOptionId;
+  }
 }

--- a/src/main/java/com/nexters/covid/letter/domain/Letter.java
+++ b/src/main/java/com/nexters/covid/letter/domain/Letter.java
@@ -62,7 +62,7 @@ public class Letter extends BaseEntity {
     this.state = State.PENDING;
     this.sticker = request.getSticker();
     this.questionId = request.getQuestionId();
-    this.sendOptionId = request.getSendOptionId();
+    this.sendOptionId = markLetterSendOptionId(request.getSendOptionId());
     this.encryptedId = generateEncryptedId();
   }
 
@@ -82,5 +82,12 @@ public class Letter extends BaseEntity {
 
   public String decodeContents() {
     return new String(decodeBase64(this.contents));
+  }
+
+  public Long markLetterSendOptionId(Long sendOptionId) {
+    if (sendOptionId == null) {
+      return 7L;
+    }
+    return sendOptionId;
   }
 }

--- a/src/main/java/com/nexters/covid/letter/domain/Letter.java
+++ b/src/main/java/com/nexters/covid/letter/domain/Letter.java
@@ -60,7 +60,7 @@ public class Letter extends BaseEntity {
 
   public Letter(LetterRequest request, User user, SendOption sendOption) {
     this.user = user;
-    this.letterTo = request.getEmail();
+    this.letterTo = user.getEmail();
     this.title = request.getTitle();
     this.contents = encodeContents(request.getContents());
     this.email = user.getEmail();

--- a/src/main/java/com/nexters/covid/letter/domain/LetterRepository.java
+++ b/src/main/java/com/nexters/covid/letter/domain/LetterRepository.java
@@ -2,6 +2,8 @@ package com.nexters.covid.letter.domain;
 
 import java.util.List;
 import java.util.Optional;
+import org.springframework.data.jpa.repository.EntityGraph;
+import org.springframework.data.jpa.repository.EntityGraph.EntityGraphType;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -9,13 +11,16 @@ import org.springframework.data.repository.query.Param;
 
 public interface LetterRepository extends JpaRepository<Letter, Long> {
 
-  List<Letter> findLettersByEmailOrderByCreatedDateDesc(String email);
+  @EntityGraph(attributePaths = "sendOption", type = EntityGraphType.FETCH)
+  List<Letter> findLettersByEmailOrderByCreatedDateDesc(@Param("email") String email);
 
+  @EntityGraph(attributePaths = "sendOption", type = EntityGraphType.FETCH)
   Optional<Letter> findLetterByEncryptedId(String encryptedId);
 
   List<Letter> findLetterByState(State state);
 
-  List<Letter> findLettersBySendOptionIdAndState(Long sendOptionId, State state);
+  @Query("select l from Letter l where l.sendOption.id = :sendOptionId and l.state = :state")
+  List<Letter> findLettersBySendOptionIdAndState(@Param("sendOptionId") Long sendOptionId, @Param("state") State state);
 
   @Modifying
   @Query("UPDATE Letter l set l.state = 'SEND' WHERE l.encryptedId = :encryptedId")

--- a/src/main/java/com/nexters/covid/letter/domain/sendoption/SendOption.java
+++ b/src/main/java/com/nexters/covid/letter/domain/sendoption/SendOption.java
@@ -30,4 +30,8 @@ public class SendOption {
 
   @OneToMany(mappedBy = "sendOption", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
   private final List<Question> questions = new ArrayList<>();
+
+  public boolean isUnpostedLetter() {
+    return id == 7L;
+  }
 }

--- a/src/main/java/com/nexters/covid/letter/service/LetterService.java
+++ b/src/main/java/com/nexters/covid/letter/service/LetterService.java
@@ -89,4 +89,14 @@ public class LetterService {
     return new LetterResponse(letter);
   }
 
+  @Transactional
+  public LetterResponse updateLetter(String encryptedId, LetterRequest letterRequest) {
+    Letter letter = letterRepository.findLetterByEncryptedId(encryptedId)
+        .map(l -> {
+          l.updateLetterSendOption(letterRequest.getSendOptionId());
+          return l;
+        }).orElseThrow(() -> new IllegalArgumentException("해당 ID의 편지가 없습니다."));
+
+    return new LetterResponse(letter);
+  }
 }

--- a/src/main/java/com/nexters/covid/letter/service/LetterService.java
+++ b/src/main/java/com/nexters/covid/letter/service/LetterService.java
@@ -67,8 +67,8 @@ public class LetterService {
   }
 
   @Transactional
-  public LetterResponse saveLetter(LetterRequest letterRequest) {
-    User user = userRepository.findUserByEmail(letterRequest.getEmail())
+  public LetterResponse saveLetter(LetterRequest letterRequest, String email) {
+    User user = userRepository.findUserByEmail(email)
         .orElseThrow(() -> new RuntimeException("사용자가 없습니다."));
     SendOption option = findSendOptionById(letterRequest.markLetterSendOptionId());
 


### PR DESCRIPTION
#### 편지 API 개발 Nexters/covid-letter-server#3

- 부치지 못한 편지/전체 편지 조회 분기 처리
- SendOption 편지 테이블과 단방향 관계 설정
- 발송 옵션 미설정시 id = 7L로 자동 설정
- 발송 옵션 추후 업데이트 기능 추가